### PR TITLE
Revert "Revert bytes param type fixes."

### DIFF
--- a/core/src/main/java/net/consensys/eventeum/chain/converter/Web3jEventParameterConverter.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/converter/Web3jEventParameterConverter.java
@@ -52,6 +52,7 @@ public class Web3jEventParameterConverter implements EventParameterConverter<Typ
         registerBytesConverters("bytes", 1, 32);
 
         typeConverters.put("byte", this::convertBytesType);
+        typeConverters.put("bytes", this::convertBytesType);
         typeConverters.put("bool", (type) -> new NumberParameter(type.getTypeAsString(),
                 (Boolean) type.getValue() ? BigInteger.ONE : BigInteger.ZERO));
         typeConverters.put("string",

--- a/core/src/main/java/net/consensys/eventeum/chain/util/Web3jUtil.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/util/Web3jUtil.java
@@ -54,6 +54,7 @@ public class Web3jUtil {
         typeMappings.put(ParameterType.build(BYTE), new TypeMapping(new TypeReference<Bytes1>() {}, Bytes1.class));
         typeMappings.put(ParameterType.build(BYTE + "[]"), new TypeMapping(
                 new TypeReference<DynamicArray<Bytes1>>() {}, DynamicArray.class));
+        typeMappings.put(ParameterType.build(BYTES), new TypeMapping(new TypeReference<DynamicBytes>() {}, DynamicBytes.class));
         typeMappings.put(ParameterType.build(ADDRESS), new TypeMapping(new TypeReference<Address>() {}, Address.class));
         typeMappings.put(ParameterType.build(ADDRESS + "[]"), new TypeMapping(
                 new TypeReference<DynamicArray<Address>>() {}, DynamicArray.class));


### PR DESCRIPTION
Type "bytes" is not supported yet in Eventeum

This reverts commit f38bfb001568a8eff5af1e3f158dcad3ff51b59f.